### PR TITLE
fixed player overwriting behaviour

### DIFF
--- a/src/App/Resources/OktolabMediaBundle/views/player/jwplayer.js.twig
+++ b/src/App/Resources/OktolabMediaBundle/views/player/jwplayer.js.twig
@@ -1,0 +1,92 @@
+<script src="{{ player_url|raw }}"></script>
+<script type="text/javascript">
+    $(document).ready(function() {
+        var playerInstance = jwplayer("{{ player_id }}");
+        playerInstance.setup({
+            playbackRateControls: true,
+            logo:   {{ origin(episode)|raw }},
+            {% if displaytitle %}
+                displaytitle: true,
+            {% else %}
+                displaytitle: false,
+            {% endif %}
+            playlist: [{
+                image: "{{ episode.posterframe|thumb(720,1280) }}",
+                title: "{{ episode.name }}",
+                {% if episode.stereomode == 1 %}
+                    stereomode: 'monoscopic',
+                {% elseif episode.stereomode == 2 %}
+                    stereomode: 'stereoscopicTopBottom',
+                {% elseif episode.stereomode == 3 %}
+                    stereomode: 'stereoscopicLeftRight',
+                {% endif %}
+                sources: [
+                    {% for media in episode.media %}
+                        {% if media.public %}
+                            {
+                                file: "{{ media.asset|link }}",
+                                label: "{{ media.quality }}",
+                                type: "mp4"
+                            }{% if not loop.last %},{% endif %}
+                        {% endif %}
+                    {% endfor %}
+                ],
+                tracks: [
+                    {% if episode.sprite is not empty %}
+                        {
+                            file: "{{ url('oktolab_media_sprite_for_episode', {'uniqID': episode.uniqID}) }}",
+                            kind: "{{ constant('Oktolab\\MediaBundle\\Entity\\Caption::OKTOLAB_CAPTIONKIND_THUMB') }}"
+                        },
+                    {% endif %}
+                    {% for caption in episode.captions %}
+                    {
+                        file: "{{ url('oktolab_media_caption_for_episode', {'uniqID': caption.uniqID}) }}",
+                        label: "{{ caption.label }}",
+                        kind: "{{ caption.kind }}"
+                    }{% if not loop.last %},{% endif %}
+                    {% endfor %}
+                ]
+            }],
+            related: {
+                    file: "{{ url('oktothek_show_similar_episode', {'uniqID': episode.uniqID})|raw }}",
+                    onclick: "link"
+            }
+        }).on('play', function(event){
+            if (event.oldstate == "buffering") { {# fire statistics #}
+                $.ajax({
+                    url: "{{ url('bprs_analytics_write_log')}}",
+                    data: {'identifier': "{{ episode.uniqID }}", 'value': 'start'}
+                });
+            }
+        }).on('complete', function(event) {
+            $.ajax({
+                url: "{{ url('bprs_analytics_write_log')}}",
+                data: {'identifier': "{{ episode.uniqID}}", 'value': 'end'}
+            });
+        }).on('time', function(event) {
+            var percentage = Math.floor(event.position*100 / event.duration);
+
+            if ( percentage == 20 ) {
+                $.ajax({
+                    url: "{{ url('bprs_analytics_write_log')}}",
+                    data: {'identifier': "{{ episode.uniqID}}", 'value': percentage+'%'}
+                });
+            } else if ( percentage == 40 ) {
+                $.ajax({
+                    url: "{{ url('bprs_analytics_write_log')}}",
+                    data: {'identifier': "{{ episode.uniqID}}", 'value': percentage+'%'}
+                });
+            } else if (percentage == 60 ) {
+                $.ajax({
+                    url: "{{ url('bprs_analytics_write_log')}}",
+                    data: {'identifier': "{{ episode.uniqID}}", 'value': percentage+'%'}
+                });
+            } else if ( percentage == 80 ) {
+                $.ajax({
+                    url: "{{ url('bprs_analytics_write_log')}}",
+                    data: {'identifier': "{{ episode.uniqID}}", 'value': percentage+'%'}
+                });
+            }
+        });
+    });
+</script>


### PR DESCRIPTION
due to removed bundle inheritance, the player must now be overwritten in the oktolabmediabundle template path instead of the oktomediabundle one.