### PR TITLE
quicklink to episode statistik from backend

### DIFF
--- a/src/AppBundle/Security/SeriesPostVoter.php
+++ b/src/AppBundle/Security/SeriesPostVoter.php
@@ -54,7 +54,10 @@ class SeriesPostVoter extends Voter
     private function canView(Series $series, User $user)
     {
         $users = $series->getUsers()->toArray();
-        return in_array($user, $users);
+        if (in_array($user, $users) || in_array($user->getRoles(), 'ROLE_USER')) {
+            return true;
+        }
+        return false;
     }
 
     // allow user to post in the backend

--- a/templates/bundles/OktoMediaBundle/episode/show.html.twig
+++ b/templates/bundles/OktoMediaBundle/episode/show.html.twig
@@ -70,6 +70,7 @@
             {{ episode.description|default('oktolab_media.show_episode_description_missing'|trans)|nl2br }}
         </div>
         <div class="col-md-5">
+            <a href="{{ path('oktothek_channel_episode', {'uniqID': episode.uniqID}) }}">Statistik</a>
             <h4>{{ 'oktolab_media_info_for_episode_header'|trans }}</h4>
             <dl class="dl-horizontal">
                 <dt>{{ 'oktolab_media.episode_info_isActive'|trans }}</dt>


### PR DESCRIPTION
moved overwritten episode template to correct path
series post voter now allows producer backend view for all accounts with ROLE_USER (okto ppl)