### PR TITLE
new trending score to speed up frontpage

### DIFF
--- a/src/AppBundle/Command/UpdateTrendingScoreCommand.php
+++ b/src/AppBundle/Command/UpdateTrendingScoreCommand.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace AppBundle\Command;
+
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class UpdateTrendingScoreCommand extends ContainerAwareCommand {
+
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    protected function configure()
+    {
+        $this
+            ->setName('homepage:media:update_trending_score')
+            ->setDescription('Updates the trending score of episodes according to the current views.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $episode_service = $this->getContainer()->get('oktothek_episode');
+        $episode_service->updateTrendingScore();
+    }
+}

--- a/src/AppBundle/Entity/Episode.php
+++ b/src/AppBundle/Entity/Episode.php
@@ -34,11 +34,18 @@ class Episode extends OktoEpisode {
      */
     private $views;
 
+    /**
+     * @ORM\Column(name="trending_score", type="integer", options={"defaults" = 0}, nullable=true)
+     * used to offload the query to set score. a cronjob should update this score every few hours.
+     */
+    private $trending_score;
+
     public function __construct()
     {
         parent::__construct();
         $this->users = new \Doctrine\Common\Collections\ArrayCollection();
         $this->views = 0;
+        $this->trending_score = 0;
     }
 
     /**
@@ -179,5 +186,15 @@ class Episode extends OktoEpisode {
     {
         $this->views = $views;
         return $this;
+    }
+
+    public function getTrendingScore()
+    {
+        return $this->trending_score;
+    }
+
+    public function setTrendingScore($score)
+    {
+        $this->trending_score = $score;
     }
 }

--- a/src/AppBundle/Entity/Repository/EpisodeRepository.php
+++ b/src/AppBundle/Entity/Repository/EpisodeRepository.php
@@ -69,57 +69,74 @@ class EpisodeRepository extends BaseEpisodeRepository
     public function findTrendingEpisodes($numberEpisodes = 8, $query_only = false)
     {
         $query = $this->getEntityManager()->createQuery(
-            "SELECT e, COUNT(l) AS HIDDEN viewCount
-            FROM AppBundle:Episode e
+            "SELECT e FROM AppBundle:Episode e
             JOIN e.series s
-            JOIN BprsAnalyticsBundle:Logstate l WITH l.identifier = e.uniqID
             WHERE e.isActive = 1
             AND s.isActive = 1
             AND e.onlineStart < :now
-            AND l.value = :value
-            AND l.timestamp > :range
-            GROUP By e.id
-            ORDER BY viewCount DESC"
-            )->setParameter('now', new \DateTime())
-            ->setParameter('value', '20%')
-            ->setParameter('range', new \DateTime('-7 days'));
+            ORDER BY e.trending_score DESC"
+            )->setParameter('now', new \DateTime());
 
         if ($query_only) {
-            $query->setHint('knp_paginator.count', 60);
+            $query->setMaxResults(60);
             return $query;
         }
 
-        $query = $this->getEntityManager()->createQuery(
-            "SELECT e.id, COUNT(l) AS HIDDEN viewCount
-            FROM AppBundle:Episode e
-            JOIN e.series s
-            JOIN BprsAnalyticsBundle:Logstate l WITH l.identifier = e.uniqID
-            WHERE e.isActive = 1
-            AND s.isActive = 1
-            AND e.onlineStart < :now
-            AND l.value = :value
-            AND l.timestamp > :range
-            GROUP By e.id
-            ORDER BY viewCount DESC"
-            )->setParameter('now', new \DateTime())
-            ->setParameter('value', '20%')
-            ->setParameter('range', new \DateTime('-7 days'));
+        return $query->setMaxResults($numberEpisodes)->getResult();
 
-        $ids = $query
-            ->setMaxResults($numberEpisodes)
-            ->getScalarResult();
 
-        $episodes = [];
-        foreach (array_column($ids, "id") as $id) {
-            $episodes[] = $this->getEntityManager()->createQuery(
-                    "SELECT e, p, s FROM AppBundle:Episode e
-                    LEFT JOIN e.series s
-                    LEFT JOIN e.posterframe p
-                    WHERE e.id = :id"
-                )->setParameter('id', $id)->getSingleResult();
-        }
-
-        return $episodes;
+        // $query = $this->getEntityManager()->createQuery(
+        //     "SELECT e, COUNT(l) AS HIDDEN viewCount
+        //     FROM AppBundle:Episode e
+        //     JOIN e.series s
+        //     JOIN BprsAnalyticsBundle:Logstate l WITH l.identifier = e.uniqID
+        //     WHERE e.isActive = 1
+        //     AND s.isActive = 1
+        //     AND e.onlineStart < :now
+        //     AND l.value = :value
+        //     AND l.timestamp > :range
+        //     GROUP By e.id
+        //     ORDER BY viewCount DESC"
+        //     )->setParameter('now', new \DateTime())
+        //     ->setParameter('value', '20%')
+        //     ->setParameter('range', new \DateTime('-7 days'));
+        //
+        // if ($query_only) {
+        //     $query->setHint('knp_paginator.count', 60);
+        //     return $query;
+        // }
+        //
+        // $query = $this->getEntityManager()->createQuery(
+        //     "SELECT e.id, COUNT(l) AS HIDDEN viewCount
+        //     FROM AppBundle:Episode e
+        //     JOIN e.series s
+        //     JOIN BprsAnalyticsBundle:Logstate l WITH l.identifier = e.uniqID
+        //     WHERE e.isActive = 1
+        //     AND s.isActive = 1
+        //     AND e.onlineStart < :now
+        //     AND l.value = :value
+        //     AND l.timestamp > :range
+        //     GROUP By e.id
+        //     ORDER BY viewCount DESC"
+        //     )->setParameter('now', new \DateTime())
+        //     ->setParameter('value', '20%')
+        //     ->setParameter('range', new \DateTime('-7 days'));
+        //
+        // $ids = $query
+        //     ->setMaxResults($numberEpisodes)
+        //     ->getScalarResult();
+        //
+        // $episodes = [];
+        // foreach (array_column($ids, "id") as $id) {
+        //     $episodes[] = $this->getEntityManager()->createQuery(
+        //             "SELECT e, p, s FROM AppBundle:Episode e
+        //             LEFT JOIN e.series s
+        //             LEFT JOIN e.posterframe p
+        //             WHERE e.id = :id"
+        //         )->setParameter('id', $id)->getSingleResult();
+        // }
+        //
+        // return $episodes;
     }
 
     public function findEpisodesForSeries($series, $query_only = false)

--- a/src/AppBundle/Model/EpisodeService.php
+++ b/src/AppBundle/Model/EpisodeService.php
@@ -32,6 +32,44 @@ class EpisodeService {
         return false;
     }
 
+    public function updateTrendingScore($numberEpisodes = 60)
+    {
+        // update the top 60 episodes with their respective viewcounts;
+        $query = $this->em->createQuery(
+            "SELECT e.id, COUNT(l) AS viewCount
+            FROM AppBundle:Episode e
+            JOIN e.series s
+            JOIN BprsAnalyticsBundle:Logstate l WITH l.identifier = e.uniqID
+            WHERE e.isActive = 1
+            AND s.isActive = 1
+            AND e.onlineStart < :now
+            AND l.value = :value
+            AND l.timestamp > :range
+            GROUP By e.id
+            ORDER BY viewCount DESC"
+            )->setParameter('now', new \DateTime())
+            ->setParameter('value', '20%')
+            ->setParameter('range', new \DateTime('-7 days'));
+
+        $scores = $query
+            ->setMaxResults($numberEpisodes)
+            ->getScalarResult();
+
+        // reset all episode scores to 0
+        $query = $this->em->createQuery(
+            "Update AppBundle:Episode e set e.trending_score = 0"
+            )->getResult();
+
+        foreach ($scores as $score) {
+            $query = $this->em->createQuery(
+                "Update AppBundle:Episode e set e.trending_score = :score WHERE e.id = :id"
+                )
+                ->setParameter('score', $score['viewCount'])
+                ->setParameter('id', $score['id'])
+                ->getResult();
+        }
+    }
+
 }
 
  ?>


### PR DESCRIPTION
will save the results from clicks in a trending score in episodes. this should be triggered by a cronjob (homepage:media:update_trending_score)

allows the trending score to be determined much more sophisticated later.